### PR TITLE
feat: Add new metrics (budget, budget spend, TPM, RPM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This exporter provides comprehensive Prometheus metrics for LiteLLM, exposing us
 ### Rate Limit Metrics
 - `litellm_tpm_limit`: Tokens per minute limit by entity (labels: entity_type, entity_id, entity_alias)
 - `litellm_rpm_limit`: Requests per minute limit by entity (labels: entity_type, entity_id, entity_alias)
-- `litellm_current_tpm`: Current tokens per minute usage (labels: entity_type, entity_id, entity_alias)
-- `litellm_current_rpm`: Current requests per minute usage (labels: entity_type, entity_id, entity_alias)
+- `litellm_current_tpm`: Current tokens per minute usage (labels: model, entity_type, entity_id, entity_alias)
+- `litellm_current_rpm`: Current requests per minute usage (labels: model, entity_type, entity_id, entity_alias)
 
 ### Cache Metrics
 - `litellm_cache_hits_total`: Total number of cache hits by model
@@ -316,8 +316,8 @@ Here are some example Prometheus queries for creating Grafana dashboards:
 - Cache hit ratio: `rate(litellm_cache_hits_total[5m]) / (rate(litellm_cache_hits_total[5m]) + rate(litellm_cache_misses_total[5m]))`
 
 ### Rate Limit Monitoring
-- TPM utilization by alias: `sum by (entity_alias) (litellm_current_tpm / litellm_tpm_limit * 100)`
-- RPM utilization by alias: `sum by (entity_alias) (litellm_current_rpm / litellm_rpm_limit * 100)`
+- TPM utilization by entity: `litellm_current_tpm / on(entity_type, entity_id) group_left(entity_alias) litellm_tpm_limit * 100`
+- RPM utilization by entity: `litellm_current_rpm / on(entity_type, entity_id) group_left(entity_alias) litellm_rpm_limit * 100`
 
 ### User/Team Activity
 - Active teams by alias: `count by (team_alias) (litellm_member_count)`

--- a/src/litellm_exporter/queries/__init__.py
+++ b/src/litellm_exporter/queries/__init__.py
@@ -172,3 +172,54 @@ class MetricQueries:
         LEFT JOIN "LiteLLM_BudgetTable" b ON v.budget_id = b.budget_id
         WHERE v.max_budget IS NOT NULL OR b.max_budget IS NOT NULL
         """
+
+    @staticmethod
+    def get_current_rate_metrics() -> str:
+        return """
+        -- User-level current rates
+        SELECT
+            s.model,
+            'user' as entity_type,
+            u.user_id as entity_id,
+            COALESCE(u.user_alias, 'none') as entity_alias,
+            SUM(s.total_tokens) as total_tokens,
+            COUNT(*) as request_count
+        FROM "LiteLLM_SpendLogs" s
+        LEFT JOIN "LiteLLM_UserTable" u ON s."user" = u.user_id
+        WHERE s."startTime" >= NOW() - INTERVAL '1 minute'
+          AND u.user_id IS NOT NULL
+        GROUP BY s.model, u.user_id, u.user_alias
+
+        UNION ALL
+
+        -- Team-level current rates
+        SELECT
+            s.model,
+            'team' as entity_type,
+            t.team_id as entity_id,
+            COALESCE(t.team_alias, 'none') as entity_alias,
+            SUM(s.total_tokens) as total_tokens,
+            COUNT(*) as request_count
+        FROM "LiteLLM_SpendLogs" s
+        LEFT JOIN "LiteLLM_TeamTable" t ON s.team_id = t.team_id
+        WHERE s."startTime" >= NOW() - INTERVAL '1 minute'
+          AND t.team_id IS NOT NULL
+        GROUP BY s.model, t.team_id, t.team_alias
+
+        UNION ALL
+
+        -- Organization-level current rates
+        SELECT
+            s.model,
+            'organization' as entity_type,
+            o.organization_id as entity_id,
+            COALESCE(o.organization_alias, 'none') as entity_alias,
+            SUM(s.total_tokens) as total_tokens,
+            COUNT(*) as request_count
+        FROM "LiteLLM_SpendLogs" s
+        LEFT JOIN "LiteLLM_TeamTable" t ON s.team_id = t.team_id
+        LEFT JOIN "LiteLLM_OrganizationTable" o ON t.organization_id = o.organization_id
+        WHERE s."startTime" >= NOW() - INTERVAL '1 minute'
+          AND o.organization_id IS NOT NULL
+        GROUP BY s.model, o.organization_id, o.organization_alias
+        """


### PR DESCRIPTION
This PR adds four new metrics:
- `litellm_key_budget`: Maximum budget for API key (labels: key_name, key_alias)
- `litellm_key_budget_spend`: Current spend for API key within budget cycle (labels: key_name, key_alias)
- `litellm_current_tpm`: Current tokens per minute usage (labels: model, entity_type, entity_id, entity_alias)
- `litellm_current_rpm`: Current requests per minute usage (labels: model, entity_type, entity_id, entity_alias)

